### PR TITLE
Fix -a ld -w ld

### DIFF
--- a/includes/custom_alloc.h
+++ b/includes/custom_alloc.h
@@ -35,6 +35,8 @@ struct malloc_s;
 
 void *alloc_instr(struct malloc_s *block, unsigned int size);
 access_t *alloc_access(struct malloc_s *block);
+void free_last_access(struct malloc_s *block);
 orig_t *alloc_orig(struct malloc_s *block);
+void free_last_orig(struct malloc_s *block);
 void custom_free_pages(struct malloc_s *block);
 #endif

--- a/includes/tree.h
+++ b/includes/tree.h
@@ -16,6 +16,6 @@ void *search_on_tree(tree_t *tree, void *addr);
 void *search_same_addr_on_tree(tree_t *tree, void *addr);
 void del_from_tree(tree_t **tree, void *start_addr, void (*)(void *), int free);
 void clean_tree(tree_t **tree, void (*)(void *), int free);
-void add_to_tree(tree_t **tree, tree_t *node);
+int add_to_tree(tree_t **tree, tree_t *node);
 
 #endif

--- a/src/allocs.c
+++ b/src/allocs.c
@@ -9,9 +9,6 @@
 #include "../includes/args.h"
 #include "../includes/out_json.h"
 
-static int malloc_init = 0;
-static int realloc_init = 0;
-
 // used to know when flush old_blocks
 // list to limit memory usage
 static int	old_blocks_count = 0;
@@ -80,21 +77,21 @@ void pre_malloc(void *wrapctx, OUT void **user_data)
   drc = drwrap_get_drcontext(wrapctx);
   dr_mutex_lock(lock);
 
-  // the first call on 64 bit and the second in 32bit
-  // are init call, so we have to do nothing
-#ifdef BUILD_64
-  if (!malloc_init++ && !realloc_init)
-    {
-      dr_mutex_unlock(lock);
-      return;
-    }
-#else
-  if (malloc_init++ == 1 && realloc_init != 1)
-    {
-      dr_mutex_unlock(lock);
-      return;
-    }
-#endif
+/*   // the first call on 64 bit and the second in 32bit */
+/*   // are init call, so we have to do nothing */
+/* #ifdef BUILD_64 */
+/*   if (!malloc_init++ && !realloc_init) */
+/*     { */
+/*       dr_mutex_unlock(lock); */
+/*       return; */
+/*     } */
+/* #else */
+/*   if (malloc_init++ == 1 && realloc_init != 1) */
+/*     { */
+/*       dr_mutex_unlock(lock); */
+/*       return; */
+/*     } */
+/* #endif */
 
   
   if (!module_is_wrapped(drc))
@@ -137,22 +134,22 @@ void pre_realloc(void *wrapctx, OUT void **user_data)
   void		*drc = drwrap_get_drcontext(wrapctx);
 
   dr_mutex_lock(lock);
-  // the first call on 64 bit and the second in 32bit
-  // are init call, so we have to do nothing
-#ifdef BUILD_64
-  if (!realloc_init)
-    {
-      realloc_init++;
-      dr_mutex_unlock(lock);
-      return;
-    }
-#else
-  if (realloc_init++ == 1)
-    {
-      dr_mutex_unlock(lock);
-      return;
-    }
-#endif
+/*   // the first call on 64 bit and the second in 32bit */
+/*   // are init call, so we have to do nothing */
+/* #ifdef BUILD_64 */
+/*   if (!realloc_init) */
+/*     { */
+/*       realloc_init++; */
+/*       dr_mutex_unlock(lock); */
+/*       return; */
+/*     } */
+/* #else */
+/*   if (realloc_init++ == 1) */
+/*     { */
+/*       dr_mutex_unlock(lock); */
+/*       return; */
+/*     } */
+/* #endif */
 
   // if size == 0, realloc call free
   if (!size)

--- a/src/block_utils.c
+++ b/src/block_utils.c
@@ -56,7 +56,8 @@ void set_addr_malloc(malloc_t *block, void *start, unsigned int flag,
       block->node.min_addr = block->start;
       block->node.high_addr = block->end;
       block->node.data = block;
-      add_to_tree(&active_blocks, (tree_t *)block);
+      if (!add_to_tree(&active_blocks, (tree_t *)block))
+	dr_custom_free(NULL, 0, block, sizeof(*block));
     }
   else
     dr_printf("Error : *alloc post wrapping call without pre wrapping\n");

--- a/src/custom_alloc.c
+++ b/src/custom_alloc.c
@@ -39,6 +39,11 @@ access_t *alloc_access(malloc_t *block)
   return &(block->access_pages->accesses[block->access_pages->header.next_idx++]);
 }
 
+void free_last_access(malloc_t *block)
+{
+  block->access_pages->header.next_idx--;
+}
+
 orig_t *alloc_orig(malloc_t *block)
 {
   if (!(block->orig_pages) ||
@@ -49,6 +54,11 @@ orig_t *alloc_orig(malloc_t *block)
     }
 
   return &(block->orig_pages->origs[block->orig_pages->header.next_idx++]);
+}
+
+void free_last_orig(malloc_t *block)
+{
+  block->orig_pages->header.next_idx--;
 }
 
 void custom_free_pages(malloc_t *block)

--- a/src/elf.c
+++ b/src/elf.c
@@ -199,7 +199,8 @@ void add_plt(const module_data_t *mod, void *got, void *drcontext)
 
   new_node->data = got;
 
-  add_to_tree(&plt_tree, new_node);
+  if (!add_to_tree(&plt_tree, new_node))
+    dr_global_free(new_node, sizeof(*new_node));
 }
 
 

--- a/src/rw.c
+++ b/src/rw.c
@@ -83,7 +83,8 @@ void incr_orig(access_t *access, size_t size, void *pc, void *drcontext,
       orig_tree->node.high_addr = pc;
       orig_tree->node.min_addr = pc;
       orig_tree->node.data = orig_tree;
-      add_to_tree(&(access->origs), (tree_t*)orig_tree);
+      if (!add_to_tree(&(access->origs), (tree_t*)orig_tree))
+	free_last_orig(block);
 
       return;
     }
@@ -125,7 +126,8 @@ access_t *get_access(size_t offset, tree_t **t_access, malloc_t *block)
   access->node.high_addr = (void *)offset;
   access->node.min_addr = (void *)offset;
 
-  add_to_tree(t_access, (tree_t*)access);
+  if (!add_to_tree(t_access, (tree_t*)access))
+    free_last_access(block);
 
   return access;
 }


### PR DESCRIPTION
Now we can monitor ld using option '-a ld -w ld' without segf
it of course also possible to monitor it via '-m ld'.
The fix remove the possibility to have to time the same block
in the tree (even if malloc is called multiple time for this block)
This also allow to remove the ugly trix for the init of
malloc/realloc in the libc, making it more portable for alternate
libc.
